### PR TITLE
Fixed unlit furnaces glowing in the dark

### DIFF
--- a/src/pocketmine/block/Furnace.php
+++ b/src/pocketmine/block/Furnace.php
@@ -28,4 +28,8 @@ class Furnace extends BurningFurnace{
 	public function getName() : string{
 		return "Furnace";
 	}
+	
+	public function getLightLevel(){
+ 	    return 0;
+ 	}
 }


### PR DESCRIPTION
This fix unlit furnaces that glows in the dark

## PR Description
Whether Furnace extending BurningFurnace actually makes sense is a different question, but that can be resolved next time.
...
